### PR TITLE
Use workaround for UI camera

### DIFF
--- a/ThirdEye/Utilities.cs
+++ b/ThirdEye/Utilities.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace CameraManager;
+
+internal static class Utilities
+{
+	internal static void ClearTexture(RenderTexture tex, bool clearDepth = true, bool clearColor = true, Color? backgroundColor = null, float depth = 1)
+	{
+		Color solidColor = backgroundColor ?? Color.clear;
+		RenderTexture rt = RenderTexture.active;
+		RenderTexture.active = tex;
+		GL.Clear(clearDepth, clearColor, solidColor, depth);
+		RenderTexture.active = rt;
+	}
+}


### PR DESCRIPTION
Enabling the amalgam UI camera is causing the PC screen to be blacked out as of base game build 98. This workaround disables the amalgam UI camera and renders it to the screen via a render texture instead.